### PR TITLE
feat: 003-member-api-charge

### DIFF
--- a/member-api/build.gradle
+++ b/member-api/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-config-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // redis
+    implementation 'org.redisson:redisson:3.17.1'
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/member-api/src/main/java/com/zerobase/memberapi/aop/BalanceLock.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/aop/BalanceLock.java
@@ -1,0 +1,10 @@
+package com.zerobase.memberapi.aop;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD) // 적용 위치 설정
+@Retention(RetentionPolicy.RUNTIME) // 적용범위, 어떤 시점까지 사용될 지 결정하는 옵션
+@Documented
+@Inherited
+public @interface BalanceLock { // @interface : 사용자가 커스텀해 사용할 수 있는 어노테이션
+    long tryLockTime() default 5000L;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/config/RedisRepositoryConfig.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/config/RedisRepositoryConfig.java
@@ -1,0 +1,72 @@
+package com.zerobase.memberapi.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisRepositoryConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + redisHost + ":" + redisPort);
+
+        return Redisson.create(config);
+    }
+
+    /**
+     * Redis 와의 연결을 위한 'Connection'을 생성합니다.
+     *
+     * @return
+     */
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        return new LettuceConnectionFactory(redisHost, redisPort);
+//    }
+
+    /**
+     * Redis 데이터 처리를 위한 템플릿을 구성합니다.
+     * 해당 구성된 RedisTemplate을 통해서 데이터 통신으로 처리되는 대한 직렬화를 수행합니다.
+     *
+     * @return
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+//        // Redis를 연결합니다.
+//        redisTemplate.setConnectionFactory(redisConnectionFactory());
+//
+//        // Key-Value 형태로 직렬화를 수행합니다.
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+//
+//        // Hash Key-Value 형태로 직렬화를 수행합니다.
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//
+//        // 기본적으로 직렬화를 수행합니다.
+//        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(stringRedisSerializer);
+        redisTemplate.setValueSerializer(stringRedisSerializer);
+        redisTemplate.setHashKeySerializer(stringRedisSerializer);
+        redisTemplate.setHashValueSerializer(stringRedisSerializer);
+
+        return redisTemplate;
+    }
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/controller/CustomerController.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/controller/CustomerController.java
@@ -1,0 +1,40 @@
+package com.zerobase.memberapi.controller;
+
+import com.zerobase.memberapi.aop.BalanceLock;
+import com.zerobase.memberapi.domain.member.form.ChargeForm;
+import com.zerobase.memberapi.security.TokenProvider;
+import com.zerobase.memberapi.service.CustomerService;
+import com.zerobase.memberapi.service.SellerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/customer")
+public class CustomerController {
+    private final CustomerService customerService;
+    private final TokenProvider tokenProvider;
+    private final ValidationErrorResponse validationErrorResponse;
+
+    @PostMapping("/charge")
+    @BalanceLock
+    public ResponseEntity<?> chargeBalance(@RequestHeader(name = "Authorization") String token,
+                                           @RequestBody @Valid ChargeForm form, Errors errors) {
+        List<ResponseError> responseErrors = validationErrorResponse.checkValidation(errors);
+        if (!responseErrors.isEmpty()) {
+            return new ResponseEntity<>(responseErrors, HttpStatus.BAD_REQUEST);
+        }
+
+        return ResponseEntity.ok(customerService.chargeBalance(tokenProvider.getUserIdFromToken(token), form));
+    }
+
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/domain/member/entity/Customer.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/domain/member/entity/Customer.java
@@ -94,4 +94,9 @@ public class Customer extends BaseEntity implements UserDetails {
                 .build();
     }
 
+    public void changeBalance(int balance) {
+        this.balance += balance;
+    }
+
+
  }

--- a/member-api/src/main/java/com/zerobase/memberapi/domain/member/form/ChargeForm.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/domain/member/form/ChargeForm.java
@@ -1,0 +1,17 @@
+package com.zerobase.memberapi.domain.member.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ChargeForm{
+    @NotNull(message = "충전 금액은 필수입니다.")
+    private int amount;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/exception/ErrorCode.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/exception/ErrorCode.java
@@ -15,7 +15,13 @@ public enum ErrorCode {
 
     // 로그인, 유저정보 가져오기
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
-    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "이메일과 패스워드를 확인해주세요.");
+    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "이메일과 패스워드를 확인해주세요."),
+    // 잔액 변경,
+    CHECK_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액을 확인해주세요."),
+
+    // Lock
+    ACCOUNT_TRANSACTION_LOCK(HttpStatus.BAD_REQUEST,"해당 계좌는 사용 중입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String description;

--- a/member-api/src/main/java/com/zerobase/memberapi/service/CustomerService.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/service/CustomerService.java
@@ -1,6 +1,7 @@
 package com.zerobase.memberapi.service;
 
 
+import com.zerobase.memberapi.domain.member.form.ChargeForm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import com.zerobase.memberapi.domain.member.dto.CustomerDto;
@@ -91,6 +92,19 @@ public class CustomerService implements UserDetailsService {
         }
 
         return CustomerDto.from(member);
+    }
+
+    @Transactional
+    public CustomerDto chargeBalance(Long id, ChargeForm form) {
+        if (form.getAmount() < 0) {
+            throw new MemberException(CHECK_AMOUNT);
+        }
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_USER));
+
+        customer.changeBalance(form.getAmount());
+
+        return CustomerDto.from(customer);
     }
 
 }

--- a/member-api/src/main/java/com/zerobase/memberapi/service/LockAopAspect.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/service/LockAopAspect.java
@@ -1,0 +1,41 @@
+package com.zerobase.memberapi.service;
+
+import com.zerobase.memberapi.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LockAopAspect {
+
+    private final LockService lockService;
+    private final TokenProvider tokenProvider;
+
+    /**
+     * @Before : 메소드가 실행되기 이전에 실행
+     * @After : 메소드의 종료 후 무조건 실행 try-catch 의 finally 같이
+     * @After-returning : 메소드가 성공적으로 완료되고 리턴한 다음 실행
+     * @After-throwing : 메소드 실행중 예외가 발생하면 실행 try-catch 의 catch 같이
+     * @Around : 메소드 호출 자체를 가로채서 메소드 실행 전후에 처리할 로직 삽입
+     */
+    // args 는 annotaion 붙은 함수의 파리미터와 순서, 개수 맞아야 aop 실행함
+    // toekn, .. : 맨 처음이 token이고 뒤에 파라미터가 있는경우
+    @Around(value = "@annotation(com.zerobase.memberapi.aop.BalanceLock) && args(token, ..)")
+    public Object aroundMethod(ProceedingJoinPoint joinPoint,
+                               String token) throws Throwable{
+        // lock 취득 시도
+        lockService.lock(tokenProvider.getUsernameFromToken(token.substring(7))); // Bearer 제외
+        try {
+            return joinPoint.proceed();
+        }finally {
+            // lock 해제
+            lockService.unlock(tokenProvider.getUsernameFromToken(token.substring(7)));
+        }
+    }
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/service/LockService.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/service/LockService.java
@@ -1,0 +1,53 @@
+package com.zerobase.memberapi.service;
+
+
+import com.zerobase.memberapi.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.zerobase.memberapi.exception.ErrorCode.ACCOUNT_TRANSACTION_LOCK;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LockService {
+    private final RedissonClient redissonClient; // 이름이 같으면 Bean 자동 주입
+
+    public void lock(String email) {
+        // user의 이메일을 lock key로 사용
+        RLock lock = redissonClient.getLock(getLockKey(email));
+        log.info("Trying lock for email : {}", email);
+
+        try {
+            // 5초동안 안무거도안하면 lock 잃음
+            // 1초 기다리는 동안 lock 풀리지않으면 취득 못함
+            boolean isLock = lock.tryLock(1, 5, TimeUnit.SECONDS);
+            if (!isLock) {
+                log.error("===Lock acquisition failed===");
+                throw new MemberException(ACCOUNT_TRANSACTION_LOCK);
+            }
+        }catch (MemberException e){
+            throw e;
+
+        }catch (Exception e) {
+            log.error("Redis lock failed", e);
+        }
+
+
+    }
+
+    public void unlock(String email) {
+        log.debug("Un lock for accountNumber : {}", email);
+        redissonClient.getLock(getLockKey(email)).unlock();
+
+    }
+
+    private static String getLockKey(String email) {
+        return "ACLK" + email;
+    }
+}

--- a/member-api/src/test/http/member_scratch.http
+++ b/member-api/src/test/http/member_scratch.http
@@ -40,3 +40,12 @@ Content-Type: application/json
   "email": "user2@gmail.com",
   "password": "qwerty"
 }
+
+### charge balance
+POST http://localhost:8080/api/member/customer/charge
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJDbVlEdjVNSzVZVXlpazhLR05Ed293PT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNDkzODc1MywiZXhwIjoxNzI1MDI1MTUzfQ.kavfMrzWueykS0QbZ2nXU69tZyclHfzdLMTFcz5_pngvhYl5nFuIwmYsYsGzeg9MkJhCqojIqFtChIkd4n4EQQ
+
+{
+  "amount": 1000
+}

--- a/member-api/src/test/java/memberapi/service/LockAopAspectTest.java
+++ b/member-api/src/test/java/memberapi/service/LockAopAspectTest.java
@@ -1,0 +1,54 @@
+package memberapi.service;
+
+import com.zerobase.memberapi.security.TokenProvider;
+import com.zerobase.memberapi.service.LockAopAspect;
+import com.zerobase.memberapi.service.LockService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LockAopAspectTest {
+    @Mock
+    private LockService lockService;
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private LockAopAspect lockAopAspect;
+
+    @Test
+    void lockAndUnlock() throws Throwable {
+        //given
+        ArgumentCaptor<String> lockArg = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> unlockArg = ArgumentCaptor.forClass(String.class);
+
+        String token = "Bearer token";
+        given(tokenProvider.getUsernameFromToken(anyString()))
+                .willReturn("aaa@gmail.com");
+
+        //when
+        lockAopAspect.aroundMethod(proceedingJoinPoint, token);
+
+        //then
+        verify(lockService, times(1)).lock(lockArg.capture());
+        verify(lockService, times(1)).unlock(unlockArg.capture());
+        assertEquals("aaa@gmail.com", lockArg.getValue());
+        assertEquals("aaa@gmail.com", unlockArg.getValue());
+    }
+
+}

--- a/member-api/src/test/java/memberapi/service/LockServiceTest.java
+++ b/member-api/src/test/java/memberapi/service/LockServiceTest.java
@@ -1,0 +1,59 @@
+package memberapi.service;
+
+
+import com.zerobase.memberapi.exception.MemberException;
+import com.zerobase.memberapi.service.LockService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import static com.zerobase.memberapi.exception.ErrorCode.ACCOUNT_TRANSACTION_LOCK;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class LockServiceTest {
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock lock;
+
+    @InjectMocks
+    private LockService lockService;
+
+    @Test
+    void successGetLock() throws InterruptedException {
+        //given
+        given(redissonClient.getLock(anyString()))
+                .willReturn(lock);
+        given(lock.tryLock(anyLong(), anyLong(), any()))
+                .willReturn(true);
+
+        //when
+
+        //then
+        assertDoesNotThrow(() -> lockService.lock("123"));
+    }
+
+    @Test
+    void failGetLock() throws InterruptedException {
+        //given
+        given(redissonClient.getLock(anyString()))
+                .willReturn(lock);
+        given(lock.tryLock(anyLong(), anyLong(), any()))
+                .willReturn(false);
+
+        //when
+        MemberException exception = assertThrows(MemberException.class, () -> lockService.lock("123"));
+
+        //then
+        assertEquals(ACCOUNT_TRANSACTION_LOCK, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 개요
- 고객 포인트 충전 서비스 구현

## 변경사항
- jwt token과 충전 금액 필요
- Redisson 라이브러리 이용해 customer 의 balance 동시성 제어
- customer 의 email을 lock key로 이용
- aop로 인터페이스 구현해 controller에 적용

## 리뷰 요청
- redisson lock 이용
- aop 이용 