### PR TITLE
feat: 004-store-api-store

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -33,7 +33,20 @@ spring:
                 headerName: Authorization
                 granted: Bearer
                 role: ROLE_SELLER
-
+        - id: store-search-api
+          uri: http://localhost:8091
+          predicates:
+            - Path=/api/store/search/**
+        - id: store-api
+          uri: http://localhost:8091
+          predicates:
+            - Path=/api/store/**
+          filters:
+            - name: AuthorizationHeaderFilter
+              args:
+                headerName: Authorization
+                granted: Bearer
+                role: ROLE_SELLER
 
     config:
       label: master

--- a/member-api/src/main/java/com/zerobase/memberapi/controller/MemberController.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/controller/MemberController.java
@@ -102,6 +102,17 @@ public class MemberController {
         return ResponseEntity.ok(TokenResponse.from(token));
     }
 
+    /**
+     * 사용자 정보 찾기
+     *
+     * @param token
+     * @return 토큰으로 찾은 유저 아이디
+     */
+    @GetMapping("/id")
+    public ResponseEntity<?> getMemberId(@RequestHeader(name = "Authorization") String token) {
+        Long id = tokenProvider.getUserIdFromToken(token);
+        return ResponseEntity.ok(id);
+    }
 
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'api-gateway'
 include 'config-server'
 include 'eureka-server'
 include 'member-api'
+include 'store-api'
 

--- a/store-api/build.gradle
+++ b/store-api/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'java'
+    id "io.spring.dependency-management"
+}
+
+group = 'com.zerobase'
+version = '0.0.1-SNAPSHOT'
+
+
+ext {
+    springCloudSleuthOtelVersion = "1.0.0-M1"
+    releaseTrainVersion = "2021.0.1"
+}
+
+
+repositories {
+    mavenCentral()
+    maven {
+        url "https://repo.spring.io/snapshot"
+    }
+    maven {
+        url "https://repo.spring.io/milestone"
+    }
+    maven {
+        url "https://repo.spring.io/release"
+    }
+}
+// MSA 용
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${releaseTrainVersion}"
+        mavenBom "org.springframework.cloud:spring-cloud-sleuth-otel-dependencies:${springCloudSleuthOtelVersion}"
+    }
+}
+
+dependencies {
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-httpclient'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-config-client'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
+
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/StoreApiApplication.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/StoreApiApplication.java
@@ -1,0 +1,18 @@
+package com.zerobase.storeapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@SpringBootApplication
+@EnableFeignClients
+@EnableJpaAuditing
+@EnableDiscoveryClient
+public class StoreApiApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(StoreApiApplication.class, args);
+    }
+}
+

--- a/store-api/src/main/java/com/zerobase/storeapi/client/MemberClient.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/MemberClient.java
@@ -1,0 +1,15 @@
+package com.zerobase.storeapi.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "member", url = "${external-api.member.url}")
+public interface MemberClient {
+
+    // 요청한 유저의 id 가져옴
+    @GetMapping("/id")
+    Long getMemberId(@RequestHeader(name = "Authorization") String token);
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/ErrorResponse.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.zerobase.storeapi.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.FieldError;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+    private String field;
+    private String message;
+
+    /**
+     * Runtime validation error가 발생하는 경우 내용 담는 클래스
+     *
+     * @param error
+     * @return
+     */
+    public static ErrorResponse of(FieldError error) {
+        return ErrorResponse.builder()
+                .field(error.getField())
+                .message(error.getDefaultMessage())
+                .build();
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/StoreController.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/StoreController.java
@@ -1,0 +1,76 @@
+package com.zerobase.storeapi.controller;
+
+import com.zerobase.storeapi.client.MemberClient;
+import com.zerobase.storeapi.domain.form.store.RegisterStore;
+import com.zerobase.storeapi.domain.form.store.UpdateStore;
+import com.zerobase.storeapi.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/store")
+public class StoreController {
+    private final StoreService storeService;
+    private final MemberClient memberClient;
+
+    @PostMapping
+    public ResponseEntity<?> registerStore(@RequestHeader(name = "Authorization") String token,
+                                           @RequestBody @Valid RegisterStore form, Errors errors) {
+
+        List<ErrorResponse> errorResponses = checkValidation(errors);
+        if (!errorResponses.isEmpty()) {
+            return new ResponseEntity<>(errorResponses, HttpStatus.BAD_REQUEST);
+        }
+        return ResponseEntity.ok(storeService.registerStore(memberClient.getMemberId(token), form));
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateStore(@RequestHeader(name = "Authorization") String token,
+                                         @RequestBody @Valid UpdateStore form, Errors errors) {
+
+        List<ErrorResponse> errorResponses = checkValidation(errors);
+        if (!errorResponses.isEmpty()) {
+            return new ResponseEntity<>(errorResponses, HttpStatus.BAD_REQUEST);
+        }
+        return ResponseEntity.ok(storeService.updateStore(memberClient.getMemberId(token), form));
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> deleteStore(@RequestHeader(name = "Authorization") String token,
+                                         @RequestParam Long id) {
+
+        return ResponseEntity.ok(storeService.deleteStore(memberClient.getMemberId(token), id));
+    }
+
+
+
+    /**
+     * validation 에러 메세지 리스트를 리턴하는 클래스
+     *
+     * @param errors
+     * @return
+     */
+    private List<ErrorResponse> checkValidation(Errors errors) {
+        List<ErrorResponse> errorResponses = new ArrayList<>();
+
+        if (errors.hasErrors()) {
+            errors.getAllErrors().forEach(error -> {
+                errorResponses.add(ErrorResponse.of((FieldError) error));
+            });
+        }
+
+        return errorResponses;
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/StoreSearchController.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/StoreSearchController.java
@@ -1,0 +1,37 @@
+package com.zerobase.storeapi.controller;
+
+import com.zerobase.storeapi.service.StoreSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/store/search")
+public class StoreSearchController {
+    private final StoreSearchService storeSearchService;
+
+    @GetMapping
+    public ResponseEntity<?> searchStoreByKeyword(@RequestParam String keyword, final Pageable pageable) {
+
+        return ResponseEntity.ok(storeSearchService.searchStoreByKeyword(keyword, pageable));
+    }
+
+    @GetMapping("/follow")
+    public ResponseEntity<?> searchStoreByFollowOrder(@RequestParam String keyword, final Pageable pageable) {
+
+        return ResponseEntity.ok(storeSearchService.searchStoreByFollowOrder(keyword, pageable));
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<?> searchStore(@RequestParam Long id) {
+
+        return ResponseEntity.ok(storeSearchService.searchStore(id));
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/BaseEntity.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.zerobase.storeapi.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    // 생성, 수정날짜 자동 업데이트
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/dto/StoreDto.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/dto/StoreDto.java
@@ -1,0 +1,36 @@
+package com.zerobase.storeapi.domain.dto;
+
+import com.zerobase.storeapi.domain.entity.Store;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreDto {
+    private Long id;
+    private Long sellerId;
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+
+    private int followCount;
+
+    private LocalDate deletedAt;
+
+    public static StoreDto from(Store store) {
+        return StoreDto.builder()
+                .id(store.getId())
+                .sellerId(store.getSellerId())
+                .name(store.getName())
+                .description(store.getDescription())
+                .thumbnailUrl(store.getThumbnailUrl())
+                .followCount(store.getFollowCount())
+                .deletedAt(store.getDeletedAt())
+                .build();
+    }
+
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/entity/Store.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/entity/Store.java
@@ -1,0 +1,66 @@
+package com.zerobase.storeapi.domain.entity;
+
+import com.zerobase.storeapi.domain.BaseEntity;
+import com.zerobase.storeapi.domain.form.store.RegisterStore;
+import com.zerobase.storeapi.domain.form.store.UpdateStore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@AuditOverride(forClass = BaseEntity.class)
+public class Store extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long sellerId; // 매장 소유 파트너 id
+
+    private String name; // 매장명
+    private String description; // 매장 설명
+    private String thumbnailUrl;
+
+    @ColumnDefault("0")
+    private int followCount;
+
+    private LocalDate deletedAt; // 매장 삭제 정보
+
+    public static Store of(Long sellerId, RegisterStore form) {
+        return Store.builder()
+                .sellerId(sellerId)
+                .name(form.getName())
+                .description(form.getDescription())
+                .thumbnailUrl(form.getThumbnailUrl())
+                .build();
+    }
+
+    public void update(UpdateStore form) {
+        this.name = form.getName();
+        this.description = form.getDescription();
+        this.thumbnailUrl = form.getThumbnailUrl();
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDate.now();
+    }
+
+    public void increaseFollow() {
+        followCount++;
+    }
+
+    public void decreaseFollow() {
+        this.followCount = Math.max(followCount - 1, 0);
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/DeleteStore.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/DeleteStore.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.form.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class DeleteStore {
+    private LocalDate deletedAt;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/RegisterStore.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/RegisterStore.java
@@ -1,0 +1,19 @@
+package com.zerobase.storeapi.domain.form.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegisterStore {
+    @NotBlank(message = "매장 이름은 필수입니다.")
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/UpdateStore.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/form/store/UpdateStore.java
@@ -1,0 +1,20 @@
+package com.zerobase.storeapi.domain.form.store;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateStore {
+    private Long id;
+    @NotBlank(message = "매장 이름은 필수입니다.")
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/exception/ErrorCode.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/exception/ErrorCode.java
@@ -1,0 +1,45 @@
+package com.zerobase.storeapi.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+
+    // 매장 등록
+    DUPLICATE_STORE_NAME(HttpStatus.BAD_REQUEST, "매장명은 중복일 수 없습니다."),
+
+    // 매장 수정
+    NOT_FOUND_STORE(HttpStatus.BAD_REQUEST, "매장 정보가 존재하지 않습니다."),
+    NOT_FOUND_ITEM(HttpStatus.BAD_REQUEST, "아이템정보가 존재하지 않습니다."),
+    ALREADY_DELETED_STORE(HttpStatus.BAD_REQUEST, "이미 삭제된 매장입니다."),
+
+    UNMATCHED_SELLER_STORE(HttpStatus.BAD_REQUEST, "매장 정보와 파트너 정보가 일치하지 않습니다."),
+    // 매장 삭제
+    // 매장 검색
+    // 아이템 등록
+    DUPLICATE_ITEM_NAME(HttpStatus.BAD_REQUEST, "아이템명은 중복일 수 없습니다."),
+    CHECK_ITEM_PRICE(HttpStatus.BAD_REQUEST, "가격을 확인해주세요."),
+
+    // 옵션 등록
+    DUPLICATE_OPTION_NAME(HttpStatus.BAD_REQUEST, "옵션명은 중복일 수 없습니다."),
+    CHECK_OPTION_PRICE(HttpStatus.BAD_REQUEST, "가격을 확인해주세요."),
+    CHECK_OPTION_QUANTITY(HttpStatus.BAD_REQUEST, "수량을 확인해주세요."),
+    CHECK_OPTION_DISCOUNT(HttpStatus.BAD_REQUEST, "할인금액이 가격보다 큽니다."),
+
+
+    // cart
+    CART_CHANGE_FAIL(HttpStatus.BAD_REQUEST, "장바구니에 추가할 수 없습니다."),
+    ORDER_FAIL_CHECK_CART(HttpStatus.BAD_REQUEST, "주문 불가, 장바구니를 확인해주세요."),
+    ORDER_FAIL_NO_MONEY(HttpStatus.BAD_REQUEST, "주문 불가, 잔액 부족입니다."),
+
+    // order
+    ITEM_QUANTITY_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "상품의 수량이 부족합니다.");
+    private final HttpStatus httpStatus;
+    private final String description;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/exception/ErrorResponse.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.zerobase.storeapi.exception;
+
+
+import lombok.*;
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class ErrorResponse {
+    // 예외 발생한 경우 예외 정보 전달 위해
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public static ErrorResponse from(StoreException e) {
+        return ErrorResponse.builder()
+                .errorMessage(e.getErrorMessage())
+                .errorCode(e.getErrorCode())
+                .build();
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/exception/GlobalExceptionHandler.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.zerobase.storeapi.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.zerobase.storeapi.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // 에러를 발생시키지 않고 응답 메시지로 클라이언트에게 전달
+    @ExceptionHandler(StoreException.class)
+    public ErrorResponse handleStoreException(StoreException e) {
+        errorLog(e.getErrorCode());
+
+        return new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    }
+
+
+
+    // 그외 에러
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse handleException(Exception e) {
+        log.error("Exception is occurred", e);
+
+        return new ErrorResponse(INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    private static void errorLog(ErrorCode e) {
+        log.error("{} is occurred", e);
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/exception/StoreException.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/exception/StoreException.java
@@ -1,0 +1,20 @@
+package com.zerobase.storeapi.exception;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreException extends RuntimeException {
+    // store 관련 에러발생한 경우
+
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public StoreException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/repository/StoreRepository.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/repository/StoreRepository.java
@@ -1,0 +1,20 @@
+package com.zerobase.storeapi.repository;
+
+import com.zerobase.storeapi.domain.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    boolean existsByName(String name);
+    Optional<Store> findByIdAndSellerId(Long id, Long sellerId);
+    Page<Store> findByNameContainingIgnoreCaseAndDeletedAt(String keyword, LocalDate deletedAt, Pageable pageable);
+
+    Page<Store> findByNameContainingIgnoreCaseAndDeletedAtOrderByFollowCountDesc(String keyword, LocalDate deletedAt, Pageable pageable);
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/service/StoreSearchService.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/service/StoreSearchService.java
@@ -1,0 +1,36 @@
+package com.zerobase.storeapi.service;
+
+import com.zerobase.storeapi.domain.dto.StoreDto;
+import com.zerobase.storeapi.domain.entity.Store;
+import com.zerobase.storeapi.exception.StoreException;
+import com.zerobase.storeapi.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import static com.zerobase.storeapi.exception.ErrorCode.NOT_FOUND_STORE;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StoreSearchService {
+    private final StoreRepository storeRepository;
+
+
+    public Page<StoreDto> searchStoreByKeyword(String keyword, Pageable pageable) {
+        return storeRepository.findByNameContainingIgnoreCaseAndDeletedAt(keyword, null, pageable)
+                .map(StoreDto::from);
+    }
+
+    public Page<StoreDto> searchStoreByFollowOrder(String keyword, Pageable pageable) {
+        return storeRepository.findByNameContainingIgnoreCaseAndDeletedAtOrderByFollowCountDesc(keyword, null, pageable)
+                .map(StoreDto::from);
+    }
+
+    public StoreDto searchStore(Long id) {
+        Store store = storeRepository.findById(id).orElseThrow(() -> new StoreException(NOT_FOUND_STORE));
+        return StoreDto.from(store);
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/service/StoreService.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/service/StoreService.java
@@ -1,0 +1,80 @@
+package com.zerobase.storeapi.service;
+
+import com.zerobase.storeapi.client.MemberClient;
+import com.zerobase.storeapi.domain.dto.StoreDto;
+import com.zerobase.storeapi.domain.entity.Store;
+import com.zerobase.storeapi.domain.form.store.DeleteStore;
+import com.zerobase.storeapi.domain.form.store.RegisterStore;
+import com.zerobase.storeapi.domain.form.store.UpdateStore;
+import com.zerobase.storeapi.exception.StoreException;
+import com.zerobase.storeapi.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+
+import static com.zerobase.storeapi.exception.ErrorCode.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StoreService {
+    private final StoreRepository storeRepository;
+    private final MemberClient memberClient;
+
+    public StoreDto registerStore(Long sellerId, RegisterStore form) {
+        checkDuplicateStoreName(form.getName());
+
+        Store store = Store.of(sellerId, form);
+        storeRepository.save(store);
+        return StoreDto.from(store);
+    }
+
+    /**
+     * 매장 이름 중복 확인
+     * exception : DUPLICATE_STORE_NAME "매장명은 중복일 수 없습니다."
+     *
+     * @param name
+     */
+    private void checkDuplicateStoreName(String name) {
+        boolean exists = storeRepository.existsByName(name);
+
+        if (exists) {
+            throw new StoreException(DUPLICATE_STORE_NAME);
+        }
+    }
+
+    @Transactional
+    public StoreDto updateStore(Long sellerId, UpdateStore form) {
+        checkDuplicateStoreName(form.getName());
+        Store store = checkMatchSellerAndStore(sellerId, form.getId());
+        checkStoreAlreadyDeleted(store.getDeletedAt());
+        store.update(form);
+        return StoreDto.from(store);
+    }
+
+    private void checkStoreAlreadyDeleted(LocalDate deletedAt) {
+        if(deletedAt != null) {
+            throw new StoreException(ALREADY_DELETED_STORE);
+        }
+    }
+
+
+    private Store checkMatchSellerAndStore(Long sellerId, Long id) {
+        return storeRepository.findByIdAndSellerId(id, sellerId)
+                .orElseThrow(() -> new StoreException(UNMATCHED_SELLER_STORE));
+    }
+
+    @Transactional
+    public DeleteStore deleteStore(Long sellerId, Long id) {
+        Store store = checkMatchSellerAndStore(sellerId, id);
+        store.delete();
+
+        // 아이템 삭제 코드 추가 필요
+        return DeleteStore.builder().deletedAt(store.getDeletedAt()).build();
+    }
+}

--- a/store-api/src/main/resources/application.yml
+++ b/store-api/src/main/resources/application.yml
@@ -1,0 +1,46 @@
+spring:
+  application:
+    name: store-api
+  profiles:
+    active: dev
+  cloud:
+    config:
+      label: master
+      profile: dev
+      uri: http://localhost:8888
+
+  config:
+    import: optional:configserver:http://localhost:8888
+
+
+  eureka: # eureka client 등록
+    instance:
+      prefer-ip-address: true # 컨테이너 기반 배포면 임의의 호스트이름이 부여되므로 true이용해 ip주소로 등록해 찾도록
+    client:
+      register-with-eureka: true
+      fetch-registry: true
+      serviceUrl:
+        defaultZone: http://localhost:8761/eureka/
+
+server:
+  port: 8091
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+external-api:
+  member:
+    url: http://localhost:8090/api/member
+#  member:
+#    url: http://member-api:8090/api/member
+#  store:
+#    url: http://localhost:8091/api/store
+#  store:
+#    url: http://store-api:8091/api/store
+  order:
+    url: http://localhost:8092/api/order
+#  order:
+#    url: http://order-api:8092/api/order

--- a/store-api/src/test/http/store_scratch.http
+++ b/store-api/src/test/http/store_scratch.http
@@ -1,0 +1,49 @@
+### register store
+POST http://localhost:8080/api/store
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJLei9BSlZhVDlLcHZpQ1ZicGY3cjdRPT0iLCJqdGkiOiJTdWJIZUtVUlJyZVFZK1dTT25Ca3RnPT0iLCJyb2xlcyI6WyJST0xFX1NFTExFUiJdLCJpYXQiOjE3MjU3MDk1MzksImV4cCI6MTcyNTc5NTkzOX0.gXQF1uTISmL18UczI45xyWWSBLIQksnWiird9s3_mC1H2suQQaofuuYbaFbhMdd_zrEcadbYnwhhC0Ht4I3DAw
+
+{
+  "name": "디디얌",
+  "description": "디디얌 베이커리&디저트",
+  "thumbnailUrl": "https://디디얌.png"
+}
+
+### register store
+POST http://localhost:8080/api/store
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJLei9BSlZhVDlLcHZpQ1ZicGY3cjdRPT0iLCJqdGkiOiJTdWJIZUtVUlJyZVFZK1dTT25Ca3RnPT0iLCJyb2xlcyI6WyJST0xFX1NFTExFUiJdLCJpYXQiOjE3MjU3MDk1MzksImV4cCI6MTcyNTc5NTkzOX0.gXQF1uTISmL18UczI45xyWWSBLIQksnWiird9s3_mC1H2suQQaofuuYbaFbhMdd_zrEcadbYnwhhC0Ht4I3DAw
+
+{
+  "name": "달달구리해닮",
+  "description": "해남으로 귀농해서 농부가 되었습니다",
+  "thumbnailUrl": "https://해닮.png"
+}
+
+### register store
+POST http://localhost:8080/api/store
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJLei9BSlZhVDlLcHZpQ1ZicGY3cjdRPT0iLCJqdGkiOiJTdWJIZUtVUlJyZVFZK1dTT25Ca3RnPT0iLCJyb2xlcyI6WyJST0xFX1NFTExFUiJdLCJpYXQiOjE3MjU3MDk1MzksImV4cCI6MTcyNTc5NTkzOX0.gXQF1uTISmL18UczI45xyWWSBLIQksnWiird9s3_mC1H2suQQaofuuYbaFbhMdd_zrEcadbYnwhhC0Ht4I3DAw
+
+{
+  "name": "바스켓베이커리",
+  "description": "#노밀가루, #노정제설탕, #노글루텐",
+  "thumbnailUrl": "https://바스켓.png"
+}
+
+### update store
+PUT http://localhost:8080/api/store
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJLei9BSlZhVDlLcHZpQ1ZicGY3cjdRPT0iLCJqdGkiOiJTdWJIZUtVUlJyZVFZK1dTT25Ca3RnPT0iLCJyb2xlcyI6WyJST0xFX1NFTExFUiJdLCJpYXQiOjE3MjU3MDk1MzksImV4cCI6MTcyNTc5NTkzOX0.gXQF1uTISmL18UczI45xyWWSBLIQksnWiird9s3_mC1H2suQQaofuuYbaFbhMdd_zrEcadbYnwhhC0Ht4I3DAw
+
+{
+  "id": 6,
+  "name": "바스켓베이커리 수정",
+  "description": "#노밀가루, #노정제설탕, #노글루텐",
+  "thumbnailUrl": "https://바스켓.png"
+}
+
+### delete store
+PATCH http://localhost:8080/api/store?id=6
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJLei9BSlZhVDlLcHZpQ1ZicGY3cjdRPT0iLCJqdGkiOiJTdWJIZUtVUlJyZVFZK1dTT25Ca3RnPT0iLCJyb2xlcyI6WyJST0xFX1NFTExFUiJdLCJpYXQiOjE3MjU3MDk1MzksImV4cCI6MTcyNTc5NTkzOX0.gXQF1uTISmL18UczI45xyWWSBLIQksnWiird9s3_mC1H2suQQaofuuYbaFbhMdd_zrEcadbYnwhhC0Ht4I3DAw

--- a/store-api/src/test/http/store_search_scratch.http
+++ b/store-api/src/test/http/store_search_scratch.http
@@ -1,0 +1,8 @@
+### search store by keyword
+GET http://localhost:8080/api/store/search?keyword=해닮&page=0&size=5
+
+### search store by keyword with follow order
+GET http://localhost:8080/api/store/search/follow?keyword=&page=0&size=5
+
+### get store detail
+GET http://localhost:8080/api/store/search/detail?id=6


### PR DESCRIPTION
## 개요
store 등록/수정/삭제/검색 구현

## 변경사항
- open feign 이용해 토큰으로 셀러 id 얻어옴
- 등록 
  - 매장명 중복확인
- 수정
  - 매장명 중복확인
  - 매장 삭제 확인
- 삭제
  - soft 삭제 -> 삭제 날짜 저장
- 검색
  - 키워드 검색
  - 팔로우 순으로 검색 
  - 매장 상세정보 확인
