### PR TITLE
feat: 005-store-api-item

### DIFF
--- a/member-api/src/main/java/com/zerobase/memberapi/client/StoreClient.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/client/StoreClient.java
@@ -1,0 +1,37 @@
+package com.zerobase.memberapi.client;
+
+import com.zerobase.memberapi.client.from.FollowForm;
+import com.zerobase.memberapi.client.from.HeartForm;
+import com.zerobase.memberapi.client.from.ItemsForm;
+import com.zerobase.memberapi.client.from.StoresForm;
+import com.zerobase.memberapi.domain.store.ItemDto;
+import com.zerobase.memberapi.domain.store.StoreDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(value = "store", url = "${external-api.store.url}")
+public interface StoreClient {
+    // store에 팔로우수 증가
+    @PostMapping("/follow")
+    boolean increaseFollow(@RequestBody FollowForm form);
+
+    @PostMapping("/unfollow")
+    boolean decreaseFollow(@RequestBody FollowForm request);
+
+    @PostMapping("/item/heart")
+    boolean increaseHeart(@RequestBody HeartForm form);
+
+    @PostMapping("/item/unheart")
+    boolean decreaseHeart(@RequestBody HeartForm request);
+
+    @PostMapping("/list")
+    Page<StoreDto> getStores(@RequestBody StoresForm request, @SpringQueryMap Pageable pageable);
+
+    @PostMapping("/item/list")
+    Page<ItemDto> getItems(@RequestBody ItemsForm request, @SpringQueryMap Pageable pageable);
+
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/client/from/FollowForm.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/client/from/FollowForm.java
@@ -1,0 +1,14 @@
+package com.zerobase.memberapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class FollowForm {
+    private Long storeId;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/client/from/HeartForm.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/client/from/HeartForm.java
@@ -1,0 +1,14 @@
+package com.zerobase.memberapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class HeartForm {
+    private Long itemId;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/client/from/ItemsForm.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/client/from/ItemsForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.memberapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ItemsForm {
+    private List<Long> heartList;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/client/from/StoresForm.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/client/from/StoresForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.memberapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StoresForm {
+    private List<Long> followList;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/controller/CustomerController.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/controller/CustomerController.java
@@ -1,6 +1,8 @@
 package com.zerobase.memberapi.controller;
 
 import com.zerobase.memberapi.aop.BalanceLock;
+import com.zerobase.memberapi.client.from.FollowForm;
+import com.zerobase.memberapi.client.from.HeartForm;
 import com.zerobase.memberapi.domain.member.form.ChargeForm;
 import com.zerobase.memberapi.security.TokenProvider;
 import com.zerobase.memberapi.service.CustomerService;
@@ -43,5 +45,57 @@ public class CustomerController {
 
         return ResponseEntity.ok(customerService.chargeBalance(tokenProvider.getUserIdFromToken(token), form));
     }
+    @GetMapping
+    public ResponseEntity<?> getCustomer(@RequestHeader(name = "Authorization") String token){
+        return ResponseEntity.ok(customerService.getCustomer(tokenProvider.getUserIdFromToken(token)));
+    }
 
+    @PostMapping("/follow")
+    public ResponseEntity<?> follow(@RequestHeader(name = "Authorization") String token, @RequestBody FollowForm form) {
+
+        return ResponseEntity.ok(customerService.follow(tokenProvider.getUserIdFromToken(token), form.getStoreId()));
+    }
+
+    @PostMapping("/unfollow")
+    public ResponseEntity<?> unfollow(@RequestHeader(name = "Authorization") String token, @RequestBody FollowForm form) {
+
+        return ResponseEntity.ok(customerService.unfollow(tokenProvider.getUserIdFromToken(token), form.getStoreId()));
+    }
+
+    @GetMapping("/stores")
+    public ResponseEntity<?> getFollowStores(@RequestHeader(name = "Authorization") String token,
+                                             Pageable pageable) {
+        return ResponseEntity.ok(customerService.getFollowStores(tokenProvider.getUserIdFromToken(token), pageable));
+    }
+
+    @PostMapping("/heart")
+    public ResponseEntity<?> heart(@RequestHeader(name = "Authorization") String token, @RequestBody HeartForm form) {
+
+        return ResponseEntity.ok(customerService.heart(tokenProvider.getUserIdFromToken(token), form));
+    }
+
+    @PostMapping("/unheart")
+    public ResponseEntity<?> unheart(@RequestHeader(name = "Authorization") String token, @RequestBody HeartForm form) {
+
+        return ResponseEntity.ok(customerService.unheart(tokenProvider.getUserIdFromToken(token), form));
+    }
+
+    @GetMapping("/items")
+    public ResponseEntity<?> getHeartItems(@RequestHeader(name = "Authorization") String token,
+                                           Pageable pageable) {
+        return ResponseEntity.ok(customerService.getHeartItems(tokenProvider.getUserIdFromToken(token), pageable));
+    }
+
+    @GetMapping("/delete/heart")
+    public ResponseEntity<?> deleteHeartItem(@RequestParam("itemId") Long id) {
+        customerService.deleteHeartItem(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/delete/follow")
+    public ResponseEntity<?> deleteFollowStore(@RequestParam("storeId") Long storeId) {
+        customerService.deleteFollowStore(storeId);
+        return ResponseEntity.ok().build();
+
+    }
 }

--- a/member-api/src/main/java/com/zerobase/memberapi/domain/member/entity/Customer.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/domain/member/entity/Customer.java
@@ -98,5 +98,20 @@ public class Customer extends BaseEntity implements UserDetails {
         this.balance += balance;
     }
 
+    public void follow(Long storeId) {
+        followList.add(storeId);
+    }
+
+    public void unfollow(Long storeId) {
+        followList.remove(storeId);
+    }
+
+    public void heart(Long itemId) {
+        heartList.add(itemId);
+    }
+
+    public void unheart(Long itemId) {
+        heartList.remove(itemId);
+    }
 
  }

--- a/member-api/src/main/java/com/zerobase/memberapi/domain/store/ItemDto.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/domain/store/ItemDto.java
@@ -1,0 +1,24 @@
+package com.zerobase.memberapi.domain.store;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ItemDto {
+    private Long id;
+    private Long storeId;
+
+    private String name;
+    private String thumbnailUrl;
+    private String description;
+    private String descriptionUrl;
+
+    private int price;
+
+
+    private float rating;
+    private long heartCount;
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/domain/store/StoreDto.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/domain/store/StoreDto.java
@@ -1,0 +1,17 @@
+package com.zerobase.memberapi.domain.store;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StoreDto {
+    private Long id;
+    private Long sellerId;
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+
+}

--- a/member-api/src/main/java/com/zerobase/memberapi/exception/ErrorCode.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/exception/ErrorCode.java
@@ -13,15 +13,23 @@ public enum ErrorCode {
     // 회원가입
     ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
 
-    // 로그인, 유저정보 가져오기
+    // 로그인, 유저정보 가져오기,
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
     LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "이메일과 패스워드를 확인해주세요."),
+
     // 잔액 변경,
     CHECK_AMOUNT(HttpStatus.BAD_REQUEST, "충전 금액을 확인해주세요."),
 
     // Lock
-    ACCOUNT_TRANSACTION_LOCK(HttpStatus.BAD_REQUEST,"해당 계좌는 사용 중입니다.");
+    ACCOUNT_TRANSACTION_LOCK(HttpStatus.BAD_REQUEST,"해당 계좌는 사용 중입니다."),
+    TRANSACTION_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 거래가 없습니다."),
+    TRANSACTION_ACCOUNT_UN_MATCH(HttpStatus.BAD_REQUEST,"이 거래는 해당 계좌에서 발생한 거래가 아닙니다."),
 
+    // store
+    ALREADY_FOLLOW_STORE(HttpStatus.BAD_REQUEST, "이미 팔로우한 매장입니다."),
+    ALREADY_HEART_ITEM(HttpStatus.BAD_REQUEST, "이미 찜한 아이템입니다."),
+    NOT_FOUND_STORE(HttpStatus.BAD_REQUEST, "매장 정보가 존재하지 않습니다."),
+    NOT_FOUND_ITEM(HttpStatus.BAD_REQUEST, "아이템 정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String description;

--- a/member-api/src/main/java/com/zerobase/memberapi/repository/CustomerRepository.java
+++ b/member-api/src/main/java/com/zerobase/memberapi/repository/CustomerRepository.java
@@ -2,8 +2,12 @@ package com.zerobase.memberapi.repository;
 
 import com.zerobase.memberapi.domain.member.entity.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,5 +16,24 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     boolean existsByEmail(String email);
 
     Optional<Customer> findByEmail(String email);
+    @Query(value = "select l.follow_list from customer_follow_list l where l.customer_id = (:customerId)", nativeQuery = true)
+    List<Long> findFollowList(@Param("customerId") Long customerId);
+
+    @Query(value = "select l.heart_list from customer_heart_list l where l.customer_id = (:customerId)", nativeQuery = true)
+    List<Long> findHeartList(@Param("customerId") Long customerId);
+
+    @Modifying
+    @Query(value = "delete from customer_follow_list l where l.follow_list = (:storeId)", nativeQuery = true)
+    void deleteFollow(@Param("storeId") Long storeId);
+
+    @Modifying
+    @Query(value = "delete from customer_heart_list l where l.heart_list = (:itemId)", nativeQuery = true)
+    void deleteHeart(@Param("itemId") Long itemId);
+
+    @Query(value = "select count(*) from customer_follow_list l where l.follow_list = (:storeId) AND l.customer_id = (:customerId)", nativeQuery = true)
+    int existsFollow(@Param("storeId") Long storeId, @Param("customerId") Long customerId);
+
+    @Query(value = "select count(*) from customer_heart_list l where l.heart_list = (:itemId) AND l.customer_id = (:customerId)", nativeQuery = true)
+    int existsHeart(@Param("itemId") Long itemId, @Param("customerId") Long customerId);
 
 }

--- a/member-api/src/test/http/member_store_scratch.http
+++ b/member-api/src/test/http/member_store_scratch.http
@@ -1,0 +1,68 @@
+### follow store
+POST http://localhost:8080/api/member/customer/follow
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "storeId": 1
+}
+
+### follow store
+POST http://localhost:8080/api/member/customer/follow
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "storeId": 3
+}
+
+### unfollow store
+POST http://localhost:8080/api/member/customer/unfollow
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "storeId": 1
+}
+
+### get follow stores
+GET http://localhost:8080/api/member/customer/stores?page=0&size=5
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+### heart item
+POST http://localhost:8080/api/member/customer/heart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "itemId": 4
+}
+
+### heart item
+POST http://localhost:8080/api/member/customer/heart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "itemId": 5
+}
+
+### unheart item
+POST http://localhost:8080/api/member/customer/unheart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+{
+  "itemId": 4
+}
+
+### get heart items
+GET http://localhost:8080/api/member/customer/items?page=0&size=5
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A
+
+### test delete follow store
+GET http://localhost:8090/api/member/customer/delete/follow?storeId=1
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMjQ5MiwiZXhwIjoxNzI1Nzk4ODkyfQ.PSFi6wYRnpnVbttaD1dYXH3blQbSTEqSgyC5Bw8tcBxyfrKuB0fYyg2MUpOvDuMoGnbpWlLTSEOGumKq7ZWF7A

--- a/store-api/src/main/java/com/zerobase/storeapi/client/MemberClient.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/MemberClient.java
@@ -12,4 +12,13 @@ public interface MemberClient {
     // 요청한 유저의 id 가져옴
     @GetMapping("/id")
     Long getMemberId(@RequestHeader(name = "Authorization") String token);
+
+    @PostMapping("/customer/delete/heart")
+    void deleteHeartItem(@RequestParam("itemId") Long id);
+
+    @PostMapping("/customer/delete/follow")
+    void deleteFollowStore(@RequestParam("storeId") Long id);
+
+    @GetMapping("/customer/balance")
+    int getBalance(@RequestHeader(name = "Authorization") String token);
 }

--- a/store-api/src/main/java/com/zerobase/storeapi/client/from/FollowForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/from/FollowForm.java
@@ -1,0 +1,12 @@
+package com.zerobase.storeapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class FollowForm {
+    private Long storeId;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/client/from/HeartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/from/HeartForm.java
@@ -1,0 +1,14 @@
+package com.zerobase.storeapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class HeartForm {
+    private Long itemId;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/client/from/ItemsForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/from/ItemsForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ItemsForm {
+    private List<Long> heartList;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/client/from/StoresForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/from/StoresForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.client.from;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StoresForm {
+    private List<Long> followList;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/StoreController.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/StoreController.java
@@ -1,6 +1,8 @@
 package com.zerobase.storeapi.controller;
 
 import com.zerobase.storeapi.client.MemberClient;
+import com.zerobase.storeapi.client.from.FollowForm;
+import com.zerobase.storeapi.client.from.StoresForm;
 import com.zerobase.storeapi.domain.form.store.RegisterStore;
 import com.zerobase.storeapi.domain.form.store.UpdateStore;
 import com.zerobase.storeapi.service.StoreService;
@@ -55,6 +57,23 @@ public class StoreController {
     }
 
 
+    @PostMapping("/follow")
+    public ResponseEntity<?> increaseFollow(@RequestBody FollowForm form) {
+
+        return ResponseEntity.ok(storeService.increaseFollow(form));
+    }
+
+    @PostMapping("/unfollow")
+    public ResponseEntity<?> decreaseFollow(@RequestBody FollowForm form) {
+
+        return ResponseEntity.ok(storeService.decreaseFollow(form));
+    }
+
+    @PostMapping("/list")
+    public ResponseEntity<?> getStores(@RequestBody StoresForm form
+            , Pageable pageable) {
+        return ResponseEntity.ok(storeService.getStores(form, pageable));
+    }
 
     /**
      * validation 에러 메세지 리스트를 리턴하는 클래스

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/StoreItemController.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/StoreItemController.java
@@ -1,6 +1,8 @@
 package com.zerobase.storeapi.controller;
 
 import com.zerobase.storeapi.client.MemberClient;
+import com.zerobase.storeapi.client.from.HeartForm;
+import com.zerobase.storeapi.client.from.ItemsForm;
 import com.zerobase.storeapi.domain.form.item.CreateItem;
 import com.zerobase.storeapi.domain.form.item.UpdateItem;
 import com.zerobase.storeapi.service.StoreItemService;
@@ -49,6 +51,24 @@ public class StoreItemController {
                                         @RequestParam Long id) {
 
         return ResponseEntity.ok(storeItemService.deleteItem(memberClient.getMemberId(token), id));
+    }
+
+
+    @PostMapping("/heart")
+    public ResponseEntity<?> increaseHeart(@RequestBody HeartForm form) {
+
+        return ResponseEntity.ok(storeItemService.increaseHeart(form));
+    }
+
+    @PostMapping("/unheart")
+    public ResponseEntity<?> decreaseHeart(@RequestBody HeartForm form) {
+
+        return ResponseEntity.ok(storeItemService.decreaseHeart(form));
+    }
+
+    @PostMapping("/list")
+    public ResponseEntity<?> getItems(@RequestBody ItemsForm form, Pageable pageable) {
+        return ResponseEntity.ok(storeItemService.getItems(form, pageable));
     }
 
     /**

--- a/store-api/src/main/java/com/zerobase/storeapi/repository/StoreItemRepository.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/repository/StoreItemRepository.java
@@ -27,5 +27,4 @@ public interface StoreItemRepository extends JpaRepository<Item, Long> {
 
     void deleteAllByStoreId(Long storeId);
 
-    List<Item> findAllByIdIn(List<Long> ids);
 }

--- a/store-api/src/main/java/com/zerobase/storeapi/repository/StoreRepository.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/repository/StoreRepository.java
@@ -14,7 +14,9 @@ import java.util.Optional;
 public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByName(String name);
     Optional<Store> findByIdAndSellerId(Long id, Long sellerId);
-    Page<Store> findByNameContainingIgnoreCaseAndDeletedAt(String keyword, LocalDate deletedAt, Pageable pageable);
 
+    Page<Store> findByNameContainingIgnoreCaseAndDeletedAt(String keyword, LocalDate deletedAt, Pageable pageable);
     Page<Store> findByNameContainingIgnoreCaseAndDeletedAtOrderByFollowCountDesc(String keyword, LocalDate deletedAt, Pageable pageable);
+
+    Page<Store> findAllByIdInAndDeletedAt(List<Long> ids, LocalDate deletedAt, Pageable pageable);
 }


### PR DESCRIPTION
## 개요
store follow & item heart 기능 구현

## 변경사항
- store follow
  - follow_list에 store_id 추가
  - 이미 팔로우한 매장인지 확인
  - open feign 이용해 store api의 store의 follow count 증가/감소
  - open feign 이용해 page로 팔로우 매장리스트 확인 가능
  - open feign 이용해 매장 삭제된 경우 고객의 팔로우 리스트에서도 store id 삭제 -> native query 이용해 customer_follow_list에 직접 delete
- item heart
  - heart_list에 item_id 추가
  - 이미 찜한 아이템인지 확인
  - open feign 이용해 store api의 item의 heart count 증가/감소
  - open feign 이용해 page로 찜한 아이템리스트 확인 가능
  - open feign 이용해 아이템 삭제된 경우 고객의 찜 리스트에서도 item id 삭제 -> native query 이용해 customer_heart_list에 직접 delete


