### PR TITLE
feat: 006-store-api-cart

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -41,6 +41,16 @@ spring:
           uri: http://localhost:8091
           predicates:
             - Path=/api/store/item/search/**
+        - id: cart-api
+          uri: http://localhost:8091
+          predicates:
+            - Path=/api/store/cart/**
+          filters:
+            - name: AuthorizationHeaderFilter
+              args:
+                headerName: Authorization
+                granted: Bearer
+                role: ROLE_CUSTOMER
         - id: store-api
           uri: http://localhost:8091
           predicates:

--- a/store-api/src/main/java/com/zerobase/storeapi/client/RedisClient.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/client/RedisClient.java
@@ -1,0 +1,54 @@
+package com.zerobase.storeapi.client;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.storeapi.domain.redis.Cart;
+import com.zerobase.storeapi.exception.StoreException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import static com.zerobase.storeapi.exception.ErrorCode.CART_CHANGE_FAIL;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisClient {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public <T> T get(Long key, Class<T> classType) {
+        return get(key.toString(), classType);
+    }
+
+    public <T> T get(String key, Class<T> classType) {
+        String redisValue = (String) redisTemplate.opsForValue().get(key);
+        if (ObjectUtils.isEmpty(redisValue)) {
+            return null;
+        } else {
+            try {
+                return objectMapper.readValue(redisValue, classType);
+            } catch (JsonProcessingException e) {
+                log.error("Parsing error", e);
+                return null;
+            }
+        }
+    }
+
+    public void put(Long key, Cart cart) {
+        put(key.toString(), cart);
+    }
+
+    private void put(String key, Cart cart) {
+        try {
+            redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(cart));
+        } catch (JsonProcessingException e) {
+            throw new StoreException(CART_CHANGE_FAIL);
+        }
+    }
+
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/config/RedisConfig.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.zerobase.storeapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(stringRedisSerializer);
+        template.setValueSerializer(stringRedisSerializer);
+        template.setHashKeySerializer(stringRedisSerializer);
+        template.setHashValueSerializer(stringRedisSerializer);
+
+        return template;
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/controller/CartController.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/controller/CartController.java
@@ -1,0 +1,43 @@
+package com.zerobase.storeapi.controller;
+
+import com.zerobase.storeapi.client.MemberClient;
+import com.zerobase.storeapi.domain.redis.Cart;
+import com.zerobase.storeapi.domain.redis.form.AddItemCartForm;
+import com.zerobase.storeapi.domain.redis.form.DeleteOptionCartForm;
+import com.zerobase.storeapi.domain.redis.form.UpdateOptionCartForm;
+import com.zerobase.storeapi.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/store/cart")
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+    private final MemberClient memberClient;
+
+    @PostMapping
+    public ResponseEntity<?> addCart(@RequestHeader(name = "Authorization") String token,
+                                     @RequestBody AddItemCartForm form){
+        return ResponseEntity.ok(cartService.addCart(memberClient.getMemberId(token), form));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getCart(@RequestHeader(name = "Authorization") String token){
+        return ResponseEntity.ok(cartService.getCart(memberClient.getMemberId(token)));
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> deleteCartOption(@RequestHeader(name = "Authorization") String token,
+                                              @RequestBody DeleteOptionCartForm form) {
+        return ResponseEntity.ok(cartService.deleteCartOption(memberClient.getMemberId(token), form));
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateCartOption(@RequestHeader(name = "Authorization") String token,
+                                              @RequestBody UpdateOptionCartForm form) {
+        return ResponseEntity.ok(cartService.updateCartOption(memberClient.getMemberId(token), form));
+    }
+
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/Cart.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/Cart.java
@@ -1,0 +1,87 @@
+package com.zerobase.storeapi.domain.redis;
+
+import com.zerobase.storeapi.domain.redis.form.AddItemCartForm;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.persistence.Id;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@RedisHash("cart")
+@Builder
+@AllArgsConstructor
+public class Cart {
+    @Id
+    private Long customerId;
+    private List<Item> items;
+    private List<String> messages;
+    private int totalPrice;
+
+    public void addMessage(String message) {
+        messages.add(message);
+    }
+
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Item implements Comparable<Item> {
+        private Long id;
+        private Long storeId;
+        private Long sellerId;
+        private String storeName;
+        private String name;
+        private List<Option> options;
+
+
+        public static Item from(AddItemCartForm form, Long sellerId) {
+            return Item.builder()
+                    .id(form.getId())
+                    .storeId(form.getStoreId())
+                    .sellerId(sellerId)
+                    .storeName(form.getStoreName())
+                    .name(form.getName())
+                    .options(form.getOptions().stream().map(Option::from).collect(Collectors.toList()))
+                    .build();
+        }
+
+
+        @Override
+        public int compareTo(Item p) {
+            return (int) (getId() - p.getId());
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Option implements Comparable<Option> {
+        private Long id;
+        private String name;
+        private Integer quantity;
+        private Integer price;
+
+        public static Option from(AddItemCartForm.Option form) {
+            return Option.builder()
+                    .id(form.getId())
+                    .name(form.getName())
+                    .quantity(form.getQuantity())
+                    .price(form.getPrice())
+                    .build();
+        }
+
+        @Override
+        public int compareTo(Option pi) {
+            return (int) (getId() - pi.getId());
+        }
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddCartResult.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddCartResult.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AddCartResult {
+    private String storeName;
+    private String name;
+    private int price;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddItemCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/AddItemCartForm.java
@@ -1,0 +1,31 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AddItemCartForm {
+    private Long id;
+    private Long storeId;
+    private String storeName;
+    private String name;
+    private List<Option> options;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Option{
+        private Long id;
+        private String name;
+        private Integer quantity;
+        private Integer price;
+    }
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/DeleteOptionCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/DeleteOptionCartForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DeleteOptionCartForm {
+    private List<Long> optionIds;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/UpdateOptionCartForm.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/domain/redis/form/UpdateOptionCartForm.java
@@ -1,0 +1,16 @@
+package com.zerobase.storeapi.domain.redis.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UpdateOptionCartForm {
+    private Long itemId;
+    private Long optionId;
+    private Integer quantity;
+}

--- a/store-api/src/main/java/com/zerobase/storeapi/repository/StoreItemRepository.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/repository/StoreItemRepository.java
@@ -27,4 +27,6 @@ public interface StoreItemRepository extends JpaRepository<Item, Long> {
 
     void deleteAllByStoreId(Long storeId);
 
+    List<Item> findAllByIdIn(List<Long> ids);
+
 }

--- a/store-api/src/main/java/com/zerobase/storeapi/service/CartService.java
+++ b/store-api/src/main/java/com/zerobase/storeapi/service/CartService.java
@@ -1,0 +1,235 @@
+package com.zerobase.storeapi.service;
+
+import com.zerobase.storeapi.client.RedisClient;
+import com.zerobase.storeapi.domain.entity.Item;
+import com.zerobase.storeapi.domain.entity.Option;
+import com.zerobase.storeapi.domain.redis.Cart;
+import com.zerobase.storeapi.domain.redis.form.AddCartResult;
+import com.zerobase.storeapi.domain.redis.form.AddItemCartForm;
+import com.zerobase.storeapi.domain.redis.form.DeleteOptionCartForm;
+import com.zerobase.storeapi.domain.redis.form.UpdateOptionCartForm;
+import com.zerobase.storeapi.exception.StoreException;
+import com.zerobase.storeapi.repository.StoreItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.zerobase.storeapi.exception.ErrorCode.NOT_FOUND_ITEM;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+    private final StoreItemRepository storeItemRepository;
+    private final RedisClient redisClient;
+
+    public AddCartResult addCart(Long customerId, AddItemCartForm form) {
+        Item item = storeItemRepository.findById(form.getId())
+                .orElseThrow(() -> new StoreException(NOT_FOUND_ITEM));
+
+        Cart cart = redisClient.get(customerId, Cart.class);
+        if (cart == null) {
+            cart = new Cart(customerId, new ArrayList<>(), new ArrayList<>(), 0);
+        }
+
+        // 이전에 같은 상품 있는지 확인
+        Optional<Cart.Item> itemOptional = cart.getItems().stream()
+                .filter(i -> i.getId().equals(form.getId()))
+                .findFirst();
+
+        if (itemOptional.isPresent()) {
+            // 같은 상품있으면 해당 상품 가져옴
+            Cart.Item redisItem = itemOptional.get();
+
+            // 담은 상품 상세
+            List<Cart.Option> options = form.getOptions().stream()
+                    .map(Cart.Option::from).collect(Collectors.toList());
+
+            // 장바구니에서 상품 가져와 item id와 option넣은 map 생성해 속도향상
+            Map<Long, Cart.Option> optionMap = redisItem.getOptions().stream().collect(Collectors.toMap(Cart.Option::getId, it -> it));
+
+            cart.setMessages(new ArrayList<>());
+
+            //추가된 제품의 이름이 기존과 달라진 경우 알림
+            if (!redisItem.getName().equals(form.getName())) {
+                cart.addMessage(redisItem.getName() + "의 정보가 변경되었습니다. 확인 부탁드립니다.");
+            }
+
+            for (Cart.Option option : options) {
+                Cart.Option redisOption = optionMap.get(option.getId());
+                // 장바구니에 없는 상품이면 추가
+                if (redisOption == null) {
+                    redisItem.getOptions().add(option);
+                } else {
+                    // 이미 있던 상품이면 변경사항 있는경우 message에 넣어 알려줌
+                    if (!redisOption.getName().equals(option.getName())) {
+                        cart.addMessage(redisOption.getName() + "의 옵션명이 변경되었습니다.");
+                    } else if (!redisOption.getPrice().equals(option.getPrice())) {
+                        cart.addMessage(redisOption.getName() +" "+ option.getPrice() + "의 가격이 변경되었습니다.");
+                    }
+                    // 장바구니에 추가로 넣은만큼 개수 증가
+                    redisOption.setQuantity(redisOption.getQuantity() + option.getQuantity());
+                }
+            }
+        } else {
+            // cart에 같은 상품 없으면 변환해서 add
+            Cart.Item newItem = Cart.Item.from(form, item.getSellerId());
+            cart.getItems().add(newItem);
+        }
+
+        cart.setTotalPrice(getTotalPrice(cart));
+
+        redisClient.put(customerId, cart);
+
+        return AddCartResult.builder()
+                .storeName(cart.getItems().get(0).getStoreName())
+                .name(cart.getItems().get(0).getName())
+                .price(cart.getItems().get(0).getOptions().get(0).getPrice())
+                .build();
+    }
+
+
+    // 상품의 가격이나 수량이 변동 될 수 있음 -> 알림 필요
+    // 메세지를 보고난 다음에는 확인 했으므로 제거
+    public Cart getCart(Long customerId) {
+        Cart cart = redisClient.get(customerId, Cart.class);
+        cart = cart != null ? cart : new Cart(customerId, new ArrayList<>(), new ArrayList<>(), 0);
+        Cart refreshCart = refreshCart(cart);
+        Cart returnCart = new Cart();
+        returnCart.setCustomerId(customerId);
+        returnCart.setItems(refreshCart.getItems());
+        returnCart.setTotalPrice(refreshCart.getTotalPrice());
+        returnCart.setMessages(refreshCart.getMessages());
+        // 메세지 리턴하고 확인했으니 기존 알림 삭제
+        refreshCart.setMessages(new ArrayList<>());
+        redisClient.put(customerId, cart);
+        return returnCart;
+    }
+
+    protected Cart refreshCart(Cart cart) {
+        // 1. 상품이나 상품의 아이템의 정보, 가격, 수량이 변경되었는지 체크하고
+        // 그에 맞는 알림 제공
+        // 2. 상품의 수량, 가격을 임의로 변경
+        Map<Long, Item> itemMap = storeItemRepository.findAllByIdIn(
+                        cart.getItems().stream().map(Cart.Item::getId).collect(Collectors.toList()))
+                .stream()
+                .collect(Collectors.toMap(Item::getId, item -> item));
+
+        for (int i = 0; i < cart.getItems().size(); i++) {
+            Cart.Item item = cart.getItems().get(i);
+            Item it = itemMap.get(item.getId());
+
+            // 카트에 담은 아이템이 삭제된경우
+            if (it == null) {
+                // 카트에서 삭제하고
+                cart.getItems().remove(item);
+                i--;
+                // 메세지 추가
+                cart.addMessage(item.getName() + " 상품이 삭제되었습니다.");
+                continue;
+            }
+
+            // 아이템이 존재하는 경우 옵션 확인
+            Map<Long, Option> optionMap = it.getOptions().stream()
+                    .collect(Collectors.toMap(Option::getId, option -> option));
+
+            List<String> tmpMessages = new ArrayList<>();
+            for (int j = 0; j < item.getOptions().size(); j++) {
+                Cart.Option cartOption = item.getOptions().get(j);
+                Option op = optionMap.get(cartOption.getId());
+
+                // 카트에 담은  옵션이 삭제된경우
+                if (op == null) {
+                    // 카트에서 삭제하고
+                    item.getOptions().remove(cartOption);
+                    j--;
+                    // 메세지 추가
+                    tmpMessages.add(cartOption.getName() + " 옵션이 삭제되었습니다.");
+                    continue;
+                }
+
+
+                boolean isPriceChanged = false, isQuantityNotEnough = false;
+                // 카트에 옵션을 담을 당시의 가격과 현재의 가격이 다른경우
+                if (!cartOption.getPrice().equals(op.getPrice())) {
+                    // flag -> true
+                    isPriceChanged = true;
+                    // 현재 가격으로 카트 내용 변경
+                    cartOption.setPrice(op.getPrice());
+                }
+
+                if (isPriceChanged) {
+                    tmpMessages.add(cartOption.getName() + " 가격이 변동되었습니다.");
+
+                }
+
+            }
+
+            if (item.getOptions().isEmpty()) {
+                cart.getItems().remove(item);
+                i--;
+                cart.addMessage(item.getName() + " 상품의 옵션이 모두 없어져 구매가 불가능합니다.");
+            } else if (!tmpMessages.isEmpty()) {
+                StringBuilder builder = new StringBuilder();
+                builder.append(item.getName()).append(" 상품의 변동사항 : ");
+                for (String msg : tmpMessages) {
+                    builder.append(msg).append("\n");
+                }
+                cart.addMessage(builder.toString());
+            }
+        }
+        cart.setTotalPrice(getTotalPrice(cart));
+        return cart;
+    }
+
+    public Cart deleteCartOption(Long customerId, DeleteOptionCartForm form) {
+        Cart cart = redisClient.get(customerId, Cart.class);
+        // 원하는 option 삭제
+        cart.getItems().forEach(item -> {
+            item.getOptions().removeIf(option -> form.getOptionIds().contains(option.getId()));
+        });
+
+        // item에 모든 옵션이 삭제된경우 item 삭제
+        List<Long> ids = new ArrayList<>();
+        cart.getItems().forEach(item -> {
+            if (item.getOptions().isEmpty()) {
+                ids.add(item.getId());
+            }
+        });
+        cart.getItems().removeIf(item -> ids.contains(item.getId()));
+        cart.setTotalPrice(getTotalPrice(cart));
+
+        redisClient.put(customerId, cart);
+        return cart;
+    }
+
+    public Cart updateCartOption(Long customerId, UpdateOptionCartForm form) {
+        Cart cart = redisClient.get(customerId, Cart.class);
+
+        // 변경원하는 옵션 찾기
+        Cart.Option newOption = cart.getItems().stream().filter(item -> item.getId().equals(form.getItemId()))
+                .findFirst()
+                .get()
+                .getOptions().stream().filter(option -> option.getId().equals(form.getOptionId()))
+                .findFirst()
+                .get();
+
+        newOption.setQuantity(form.getQuantity());
+        cart.setTotalPrice(getTotalPrice(cart));
+
+        redisClient.put(customerId, cart);
+        return cart;
+    }
+
+    public int getTotalPrice(Cart cart) {
+        return cart.getItems().stream().flatMapToInt(
+                p -> p.getOptions().stream().flatMapToInt(
+                        option -> IntStream.of(option.getPrice() * option.getQuantity()))).sum();
+    }
+}
+

--- a/store-api/src/test/http/cart_scratch.http
+++ b/store-api/src/test/http/cart_scratch.http
@@ -1,0 +1,77 @@
+### cart 등록
+POST localhost:8080/api/store/cart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMzg0MSwiZXhwIjoxNzI1ODAwMjQxfQ.xhlHHQAY0Czr8lCu76XMXo2_OLTjnLLu8tkgK4_KCjZmf24OtuPJC0IU281ZhwNKNo_dE01Tr-vLbJiwB54Mgw
+
+{
+  "id": 1,
+  "storeId": 1,
+  "storeName": "디디얌",
+  "name": "디디얌 마카롱 수제 뚱카롱 32종",
+  "options": [
+    {
+      "id": 1,
+      "name": "조리퐁",
+      "quantity": 1,
+      "price": 2500
+    },
+    {
+      "id": 2,
+      "name": "딸기바나나",
+      "quantity": 2,
+      "price": 2500
+    }
+  ]
+}
+
+### cart 등록
+POST localhost:8080/api/store/cart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMzg0MSwiZXhwIjoxNzI1ODAwMjQxfQ.xhlHHQAY0Czr8lCu76XMXo2_OLTjnLLu8tkgK4_KCjZmf24OtuPJC0IU281ZhwNKNo_dE01Tr-vLbJiwB54Mgw
+
+{
+  "id": 6,
+  "storeId": 2,
+  "storeName": "달달구리해닮",
+  "name": "샹티크림끌레오르",
+  "options": [
+    {
+      "id": 12,
+      "name": "블루베리샹티크림 끌레오르",
+      "quantity": 2,
+      "price": 26000
+    },
+    {
+      "id": 11,
+      "name": "얼그레이샹티크림 끌레오르",
+      "quantity": 2,
+      "price": 26000
+    }
+  ]
+}
+
+
+### cart 조회
+GET localhost:8080/api/store/cart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMzg0MSwiZXhwIjoxNzI1ODAwMjQxfQ.xhlHHQAY0Czr8lCu76XMXo2_OLTjnLLu8tkgK4_KCjZmf24OtuPJC0IU281ZhwNKNo_dE01Tr-vLbJiwB54Mgw
+
+### cart 옵션 삭제
+PATCH localhost:8080/api/store/cart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMzg0MSwiZXhwIjoxNzI1ODAwMjQxfQ.xhlHHQAY0Czr8lCu76XMXo2_OLTjnLLu8tkgK4_KCjZmf24OtuPJC0IU281ZhwNKNo_dE01Tr-vLbJiwB54Mgw
+
+{
+  "optionIds": [12, 2]
+}
+
+### cart 옵션 수량 변경
+PUT localhost:8080/api/store/cart
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlYWg0WSthVnpjbzNDMDYwYWMvRk1nPT0iLCJqdGkiOiJxaWpTQWpEdVVGUVZ5WmwxZDErbGdRPT0iLCJyb2xlcyI6WyJST0xFX0NVU1RPTUVSIl0sImlhdCI6MTcyNTcxMzg0MSwiZXhwIjoxNzI1ODAwMjQxfQ.xhlHHQAY0Czr8lCu76XMXo2_OLTjnLLu8tkgK4_KCjZmf24OtuPJC0IU281ZhwNKNo_dE01Tr-vLbJiwB54Mgw
+
+{
+  "itemId": 6,
+  "optionId": 11,
+  "quantity": 3
+}


### PR DESCRIPTION
## 개요
장바구니 기능 구현

## 변경사항
- 사용하는 db인 mysql를 이용해 장바구니를 구현하는 경우 장바구니 수정은 빈번히 일어나는 이벤트이기 때문에 i/o속도가 느려짐 -> in memory DB인 redis를 이용
- customerId를 키로 아이템과 옵션을 저장
- 장바구니에 담은 옵션의 정보가 변경된 경우 카트의 메세지에 추가해 카트 조회시 확인 가능
